### PR TITLE
Added structcol to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='infer_structcol',
       author_email='vhwang@g.harvard.edu',
       license='GNU GPL v3',
       packages=['infer_structcol'],
-      requires=['structcol','numpy', 'scipy','emcee','matplotlib', 'pint', 'lmfit'],
+      install_requires=['structcol','numpy', 'scipy','emcee','matplotlib', 'pint', 'lmfit'],
+      dependency_links=['http://github.com/manoharan-lab/structural-color/tarball/master#egg=structcol'],
       zip_safe=False)
-


### PR DESCRIPTION
The tests failed because 'structcol' is not an open package that wasn't getting installed with setup.py. The link to the package in the 'manoharan-lab' repo has been added.